### PR TITLE
Update tests.yaml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,9 +30,6 @@ jobs:
       shell: bash
       run: |
         python --version
-        conda create -n aurora-test
-        source activate aurora-test
-        conda config --add channels conda-forge
         conda install pytest
         conda install pytest-cov
         pip install git+https://github.com/kujaku11/mt_metadata.git
@@ -42,14 +39,12 @@ jobs:
     - name: Install Our Package
       shell: bash
       run: |
-        source activate aurora-test
         pip install -e .
         conda list
 
     - name: Run Tests
       shell: bash
       run: |
-        source activate aurora-test
         pytest -v --cov=./ --cov-report=xml --cov=aurora
         
     - name: "Upload coverage to Codecov"


### PR DESCRIPTION
I think this should work for the actions.

This will make the tests run on the different versions as expected 

Fix for #88

The issue was that creating a new environment defaulted to 3.9 every time. It doesn't seem quite necessary here as the environment created by the setup_minconda step will set all of the necessary parameters and create a new environment for you.