### PR TITLE
simplify test script, and add documentation deploy step.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ jobs:
   setup-build:
     name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
@@ -19,39 +22,51 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Conda
-      uses: s-weigand/setup-conda@v1
+
+    - name: Setup Miniconda
+      uses: conda-incubator/setup-miniconda@v2.1.1
       with:
-        update-conda: true
-        conda-channels: conda-forge
+        activate-environment: aurora-test
+        channels: conda-forge
         python-version: ${{ matrix.python-version }}
 
     - name: Install Env
-      shell: bash
       run: |
         python --version
-        conda create -n aurora-test
-        source activate aurora-test
-        conda config --add channels conda-forge
-        conda install pytest
-        conda install pytest-cov
+        conda install pytest pytest-cov
         pip install git+https://github.com/kujaku11/mt_metadata.git
         pip install git+https://github.com/kujaku11/mth5.git
         #pip install -e git+https://github.com/kujaku11/mth5_test_data.git#egg=mth5_test_data
-        
+
     - name: Install Our Package
-      shell: bash
       run: |
-        source activate aurora-test
         pip install -e .
         conda list
+
     - name: Run Tests
-      shell: bash
       run: |
-        source activate aurora-test
         pytest -v --cov=./ --cov-report=xml --cov=aurora
-        
+
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true
+
+    - name: Build Doc
+      if: github.ref == 'refs/heads/main'
+      run: |
+        cd docs
+        make html
+        cd ..
+
+    - name: GitHub Pages
+      if: github.ref == 'refs/heads/main'
+      uses: crazy-max/ghaction-github-pages@v2.5.0
+      with:
+        build_dir: docs/_build/html
+        # Write the given domain name to the CNAME file
+        # fqdn: aurora.simpeg.xyz
+        # Allow Jekyll to build your site
+        jekyll: false # optional, default is true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Noticed the documentation itself didn't look to be building, this will push it to a gh-pages branch from the GitHub actions workflow on commits to `main`. You might want to adjust when documentation is published though, and adjust some other parameters. (oh and I simplified the testing script a bit).

You should also add a documentation test to ensure it builds properly before deploying.