### PR TITLE
Fix issue 175

### DIFF
--- a/aurora/config/metadata/run.py
+++ b/aurora/config/metadata/run.py
@@ -117,7 +117,25 @@ class Run(Base):
             scales[ch.id] = ch.scale_factor
             
         return scales
-                
+
+    @channel_scale_factors.setter
+    def channel_scale_factors(self, values):
+        """
+        Parameters
+        ----------
+        values: dict
+            expected to be keyed like
+            {"ex":1.0, "ey":1.0, "hx":1.0, "hy":1.0, "hz":1.0}
+
+        """
+        if not isinstance(values, dict):
+            raise TypeError(f"not sure what to do with type {type(values)}")
+        for i, channel in enumerate(self.input_channels):
+            if channel.id in values.keys():
+                self.input_channels[i].scale_factor = values[channel.id]
+        for i, channel in enumerate(self.output_channels):
+            if channel.id in values.keys():
+                self.output_channels[i].scale_factor = values[channel.id]
 
         
     

--- a/aurora/config/metadata/station.py
+++ b/aurora/config/metadata/station.py
@@ -114,7 +114,8 @@ class Station(Base):
                     "sample_rate": run.sample_rate,
                     "input_channels": run.input_channel_names,
                     "output_channels": run.output_channel_names,
-                    "remote": self.remote}
+                    "remote": self.remote,
+                    "channel_scale_factors": run.channel_scale_factors}
                 data_list.append(entry)
                 
         df = pd.DataFrame(data_list)

--- a/aurora/config/metadata/station.py
+++ b/aurora/config/metadata/station.py
@@ -152,7 +152,7 @@ class Station(Base):
         self.id = df.station_id.unique()[0]
         self.mth5_path = df.mth5_path.unique()[0]
         self.remote = df.remote.unique()[0]
-        
+
         for entry in df.itertuples():
             try:
                 r = self.run_dict[entry.run_id]
@@ -160,12 +160,16 @@ class Station(Base):
                                                  end=entry.end.isoformat()))
                 
             except KeyError:
+                if hasattr(entry, "channel_scale_factors"):
+                    channel_scale_factors = entry.channel_scale_factors
+                else:
+                    channel_scale_factors = {}
                 r = Run(
                     id=entry.run_id, 
                     sample_rate=entry.sample_rate,
                     input_channels=entry.input_channels,
                     output_channels=entry.output_channels,
-                    channel_scale_factors=entry.channel_scale_factors
+                    channel_scale_factors=channel_scale_factors
                     )
                 
                 r.time_periods.append(TimePeriod(start=entry.start.isoformat(),

--- a/aurora/config/metadata/station.py
+++ b/aurora/config/metadata/station.py
@@ -163,7 +163,8 @@ class Station(Base):
                     id=entry.run_id, 
                     sample_rate=entry.sample_rate,
                     input_channels=entry.input_channels,
-                    output_channels=entry.output_channels
+                    output_channels=entry.output_channels,
+                    channel_scale_factors=entry.channel_scale_factors
                     )
                 
                 r.time_periods.append(TimePeriod(start=entry.start.isoformat(),

--- a/aurora/test_utils/synthetic/make_processing_configs.py
+++ b/aurora/test_utils/synthetic/make_processing_configs.py
@@ -1,9 +1,8 @@
 from aurora.config import BANDS_DEFAULT_FILE
 from aurora.config import BANDS_256_FILE
 from aurora.config.config_creator import ConfigCreator
-from aurora.general_helper_functions import TEST_PATH
-
-CONFIG_PATH = TEST_PATH.joinpath("synthetic", "config")
+from aurora.test_utils.synthetic.paths import CONFIG_PATH
+from aurora.test_utils.synthetic.paths import DATA_PATH
 
 
 def create_test_run_config(test_case_id, ds_df, matlab_or_fortran="", save="json"):
@@ -105,11 +104,10 @@ def test_to_from_json():
     """
     import pandas as pd
     from aurora.config.metadata import Processing
-    from aurora.general_helper_functions import TEST_PATH
     from aurora.tf_kernel.dataset import RUN_SUMMARY_COLUMNS
 
     #Specify path to mth5
-    data_path = TEST_PATH.joinpath("synthetic").joinpath("data").joinpath("test1.h5")
+    data_path = DATA_PATH.joinpath("test1.h5")
     if not data_path.exists():
         print("You need to run make_mth5_from_asc.py")
         raise Exception

--- a/aurora/test_utils/synthetic/paths.py
+++ b/aurora/test_utils/synthetic/paths.py
@@ -1,0 +1,8 @@
+from aurora.general_helper_functions import TEST_PATH
+
+SYNTHETIC_PATH = TEST_PATH.joinpath("synthetic")
+CONFIG_PATH = SYNTHETIC_PATH.joinpath("config")
+DATA_PATH = SYNTHETIC_PATH.joinpath("data")
+EMTF_OUTPUT_PATH = SYNTHETIC_PATH.joinpath("emtf_output")
+AURORA_RESULTS_PATH = SYNTHETIC_PATH.joinpath("aurora_results")
+AURORA_RESULTS_PATH.mkdir(exist_ok=True)

--- a/aurora/test_utils/synthetic/synthetic_station_config.py
+++ b/aurora/test_utils/synthetic/synthetic_station_config.py
@@ -18,7 +18,7 @@ Or we could the station info in a dictionary and formlize it with a standards.js
 
 import random
 
-from aurora.general_helper_functions import TEST_PATH
+from aurora.test_utils.synthetic.paths import DATA_PATH
 from aurora.time_series.filters.filter_helpers import make_coefficient_filter
 
 random.seed(0)
@@ -50,8 +50,8 @@ def make_filters(as_list=False):
 
 def make_station_01_config_dict():
     station_dict = {}
-    station_dict["raw_data_path"] = TEST_PATH.joinpath("synthetic", "data", "test1.asc")
-    station_dict["mth5_path"] = TEST_PATH.joinpath("synthetic", "data", "test1.h5")
+    station_dict["raw_data_path"] = DATA_PATH.joinpath("test1.asc")
+    station_dict["mth5_path"] = DATA_PATH.joinpath("test1.h5")
     station_dict["columns"] = ["hx", "hy", "hz", "ex", "ey"]
     station_dict["noise_scalar"] = {}
     for col in station_dict["columns"]:
@@ -87,8 +87,8 @@ def make_station_01_config_dict():
 
 def make_station_02_config_dict():
     station_dict = make_station_01_config_dict()
-    station_dict["raw_data_path"] = TEST_PATH.joinpath("synthetic", "data", "test2.asc")
-    station_dict["mth5_path"] = TEST_PATH.joinpath("synthetic", "data", "test2.h5")
+    station_dict["raw_data_path"] = DATA_PATH.joinpath("test2.asc")
+    station_dict["mth5_path"] = DATA_PATH.joinpath("test2.h5")
     station_dict["station_id"] = "test2"
     station_dict["nan_indices"] = {}
     for col in station_dict["columns"]:

--- a/aurora/tf_kernel/dataset.py
+++ b/aurora/tf_kernel/dataset.py
@@ -32,6 +32,7 @@ def channel_summary_to_run_summary(ch_summary,
             "input_channels",
             "output_channels",
             "remote",
+	    "channel_scale_factors",
         ]
 
     Parameters
@@ -72,6 +73,7 @@ def channel_summary_to_run_summary(ch_summary,
     sample_rates = n_station_runs * [None]
     input_channels = n_station_runs * [None]
     output_channels = n_station_runs * [None]
+    channel_scale_factors = n_station_runs * [None]
     i = 0
     for (station_id, run_id), group in grouper:
         print(f"{i} {station_id} {run_id}")
@@ -82,8 +84,10 @@ def channel_summary_to_run_summary(ch_summary,
         end_times[i] = group.end.iloc[0]
         sample_rates[i] = group.sample_rate.iloc[0]
         channels_list = group.component.to_list()
+        num_channels = len(channels_list)
         input_channels[i] = [x for x in channels_list if x in allowed_input_channels]
         output_channels[i] = [x for x in channels_list if x in allowed_output_channels]
+        channel_scale_factors[i] = dict(zip(channels_list, num_channels*[1.0]))
         i += 1
 
     data_dict = {}
@@ -94,6 +98,7 @@ def channel_summary_to_run_summary(ch_summary,
     data_dict["sample_rate"] = sample_rates
     data_dict["input_channels"] = input_channels
     data_dict["output_channels"] = output_channels
+    data_dict["channel_scale_factors"] = channel_scale_factors
     run_summary = pd.DataFrame(data=data_dict)
     return run_summary
 

--- a/aurora/tf_kernel/dataset.py
+++ b/aurora/tf_kernel/dataset.py
@@ -1,6 +1,5 @@
 """
-This will likely wind up in
-aurora/transfer_function/tf_kernel/dataset.py
+This will likely wind up in aurora/transfer_function/tf_kernel/dataset.py
 """
 
 import copy

--- a/tests/config/test_dataset_dataframe.py
+++ b/tests/config/test_dataset_dataframe.py
@@ -48,7 +48,8 @@ class TestStationDataset(unittest.TestCase):
                                   'sample_rate',
                                   'input_channels',
                                   'output_channels',
-                                  "remote"])
+                                  "remote",
+                                  "channel_scale_factors"])
             
         with self.subTest("single station"):
             self.assertTrue(len(df.station_id.unique())==1)

--- a/tests/synthetic/test_compare_aurora_vs_archived_emtf.py
+++ b/tests/synthetic/test_compare_aurora_vs_archived_emtf.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
-from aurora.general_helper_functions import TEST_PATH
 from aurora.sandbox.io_helpers.zfile_murphy import read_z_file
 from aurora.test_utils.synthetic.make_mth5_from_asc import create_test1_h5
 from aurora.test_utils.synthetic.make_mth5_from_asc import create_test2_h5
 from aurora.test_utils.synthetic.make_mth5_from_asc import create_test12rr_h5
 from aurora.test_utils.synthetic.make_processing_configs import create_test_run_config
+from aurora.test_utils.synthetic.paths import AURORA_RESULTS_PATH
+from aurora.test_utils.synthetic.paths import SYNTHETIC_PATH
+from aurora.test_utils.synthetic.paths import EMTF_OUTPUT_PATH
 from aurora.test_utils.synthetic.processing_helpers import process_sythetic_data
 from aurora.test_utils.synthetic.rms_helpers import assert_rms_misfit_ok
 from aurora.test_utils.synthetic.rms_helpers import compute_rms
@@ -16,18 +18,7 @@ from aurora.transfer_function.emtf_z_file_helpers import (
     merge_tf_collection_to_match_z_file,
 )
 
-
 from plot_helpers_synthetic import plot_rho_phi
-
-SYNTHETIC_PATH = TEST_PATH.joinpath("synthetic")
-CONFIG_PATH = SYNTHETIC_PATH.joinpath("config")
-DATA_PATH = SYNTHETIC_PATH.joinpath("data")
-EMTF_OUTPUT_PATH = SYNTHETIC_PATH.joinpath("emtf_output")
-AURORA_RESULTS_PATH = SYNTHETIC_PATH.joinpath("aurora_results")
-AURORA_RESULTS_PATH.mkdir(exist_ok=True)
-
-
-
 
 
 def aurora_vs_emtf(test_case_id,

--- a/tests/synthetic/test_synthetic_driver.py
+++ b/tests/synthetic/test_synthetic_driver.py
@@ -3,6 +3,7 @@ from aurora.test_utils.synthetic.make_mth5_from_asc import create_test1_h5
 from aurora.test_utils.synthetic.make_mth5_from_asc import create_test2_h5
 from aurora.test_utils.synthetic.make_mth5_from_asc import create_test12rr_h5
 from aurora.test_utils.synthetic.make_processing_configs import create_test_run_config
+from aurora.test_utils.synthetic.paths import AURORA_RESULTS_PATH
 from aurora.test_utils.synthetic.paths import CONFIG_PATH
 from aurora.test_utils.synthetic.processing_helpers import process_sythetic_data
 from aurora.tf_kernel.dataset import DatasetDefinition
@@ -39,7 +40,7 @@ from aurora.tf_kernel.helpers import extract_run_summaries_from_mth5s
 #     process_mth5_run(test_config, run_id, units="MT")
 
 
-def process_synthetic_1():
+def process_synthetic_1(z_file_path="", test_scale_factor=False):
     """
 
     Returns
@@ -54,9 +55,27 @@ def process_synthetic_1():
     dataset_definition = DatasetDefinition()
     dataset_definition.df = dataset_df
     #Test that channel_scale_factors column is optional
-    dataset_df.drop(columns=["channel_scale_factors"], inplace=True)
+    if test_scale_factor:
+        scale_factors = {'ex': 10.0, 'ey': 3.0, 'hx': 6.0, 'hy': 5.0, 'hz': 100.0}
+        dataset_df["channel_scale_factors"].at[0] = scale_factors
+    else:
+        dataset_df.drop(columns=["channel_scale_factors"], inplace=True)
     processing_config = create_test_run_config("test1", dataset_df)
-    tfc = process_sythetic_data(processing_config, dataset_definition)
+    tfc = process_sythetic_data(processing_config,
+                                dataset_definition,
+                                z_file_path=z_file_path)
+
+    z_figure_name = z_file_path.name.replace("zss", "png")
+    for xy_or_yx in ["xy", "yx"]:
+        ttl_str = f"{xy_or_yx} component, test_scale_factor = {test_scale_factor}"
+        out_png_name = f"{xy_or_yx}_{z_figure_name}"
+        tfc.rho_phi_plot(
+            xy_or_yx=xy_or_yx,
+            ttl_str=ttl_str,
+            show=False,
+            figure_basename=out_png_name,
+            figure_path=AURORA_RESULTS_PATH
+        )
     return tfc
 
 
@@ -88,13 +107,27 @@ def test_process_mth5():
     """
     Runs several synthetic processing tests from config creation to tf_collection.
     TODO: Modify these tests so that they output tfs using mt_metadata transfer function
+
+    2022-05-13: Added a duplicate run of process_synthetic_1, which is intended to
+    test the channel_scale_factors in the new mt_metadata processing class.  Expected
+    outputs are four .png:
+    xy_syn1.png : Shows expected 100 Ohm-m resisitivity
+    xy_syn1_scaled.png : Overestimates by 4x for 300 Ohm-m resistivity
+    yx_syn1.png : Shows expected 100 Ohm-m resisitivity
+    yx_syn1_scaled.png : Underestimates by 4x for 25 Ohm-m resistivity
+    These .png are stores in aurora_results folder
+
     Returns
     -------
 
     """
     # process_synthetic_1_underdetermined()
     # process_synthetic_1_with_nans()
-    tfc = process_synthetic_1()
+
+    z_file_path=AURORA_RESULTS_PATH.joinpath("syn1.zss")
+    tfc = process_synthetic_1(z_file_path=z_file_path)
+    z_file_path=AURORA_RESULTS_PATH.joinpath("syn1_scaled.zss")
+    tfc = process_synthetic_1(z_file_path=z_file_path, test_scale_factor=True)
     tfc = process_synthetic_2()
     tfc = process_synthetic_rr12()
 

--- a/tests/synthetic/test_synthetic_driver.py
+++ b/tests/synthetic/test_synthetic_driver.py
@@ -56,6 +56,8 @@ def process_synthetic_1():
     dataset_df["remote"] = False
     dataset_definition = DatasetDefinition()
     dataset_definition.df = dataset_df
+    #Test that channel_scale_factors column is optional
+    dataset_df.drop(columns=["channel_scale_factors"], inplace=True)
     processing_config = create_test_run_config("test1", dataset_df)
     tfc = process_sythetic_data(processing_config, dataset_definition)
     return tfc

--- a/tests/synthetic/test_synthetic_driver.py
+++ b/tests/synthetic/test_synthetic_driver.py
@@ -1,15 +1,12 @@
-from aurora.general_helper_functions import TEST_PATH
 from aurora.pipelines.process_mth5 import process_mth5_run
 from aurora.test_utils.synthetic.make_mth5_from_asc import create_test1_h5
 from aurora.test_utils.synthetic.make_mth5_from_asc import create_test2_h5
 from aurora.test_utils.synthetic.make_mth5_from_asc import create_test12rr_h5
 from aurora.test_utils.synthetic.make_processing_configs import create_test_run_config
+from aurora.test_utils.synthetic.paths import CONFIG_PATH
 from aurora.test_utils.synthetic.processing_helpers import process_sythetic_data
 from aurora.tf_kernel.dataset import DatasetDefinition
 from aurora.tf_kernel.helpers import extract_run_summaries_from_mth5s
-
-CONFIG_PATH = TEST_PATH.joinpath("synthetic", "config")
-
 
 
 


### PR DESCRIPTION
Modifications in this PR enable a column in the dataset_dataframe (aka run_summary) called "channel_scale_factors".

This should be reviewed in future, as using "channel_scale_factors" in general is a workaround, and shouldn't normally be needed, however, over the past while in dev it has been quite useful in debugging errors in metadata.

The point is that I would like this column to be optional, so it should be tested whether this column is required and if it is then add a note to issue #175 about adding that flexibility