### PR TITLE
clock zero

### DIFF
--- a/aurora/config/metadata/decimation_level.py
+++ b/aurora/config/metadata/decimation_level.py
@@ -131,7 +131,18 @@ class DecimationLevel(Base):
                                          self.window.num_samples)
         return frequency_bands
 
-    
+
+    @property
+    def windowing_scheme(self):
+        from aurora.time_series.windowing_scheme import WindowingScheme
+        windowing_scheme = WindowingScheme(
+            taper_family=self.window.type,
+            num_samples_window=self.window.num_samples,
+            num_samples_overlap=self.window.overlap,
+            taper_additional_args=self.window.additional_args,
+            sample_rate=self.decimation.sample_rate,
+        )
+        return windowing_scheme
 
     # def to_stft_config_dict(self):
     #     """

--- a/aurora/config/metadata/standards/window.json
+++ b/aurora/config/metadata/standards/window.json
@@ -48,5 +48,30 @@
         "alias": [],
         "example": "hamming",
 		"default": "boxcar"
+    },
+    "clock_zero_type": {
+      "type": "string",
+      "required": true,
+      "units": null,
+      "style": "controlled vocabulary",
+      "description": "how the clock-zero is specified",
+      "options": [
+        "user specified",
+        "data start",
+        "ignore"],
+      "alias": [],
+      "example": "user specified",
+      "default": "ignore"
+    },
+    "clock_zero": {
+      "type": "string",
+      "required": false,
+      "units": null,
+      "style": "time",
+      "description": "Start date and time of the first data window",
+      "options": [],
+      "alias": [],
+      "example": "2020-02-01T09:23:45.453670+00:00",
+      "default": "1980-01-01T00:00:00+00:00"
     }
 }

--- a/aurora/pipelines/process_mth5.py
+++ b/aurora/pipelines/process_mth5.py
@@ -107,13 +107,9 @@ def make_stft_objects(processing_config, i_dec_level, run_obj, run_xrts, units,
     """
     Operates on a "per-run" basis
 
-    Note 1: CHECK DATA COVERAGE IS THE SAME IN BOTH LOCAL AND RR
-    This should be pushed into a previous validator before pipeline starts
-    # if config.reference_station_id:
-    #    local_run_xrts = local_run_xrts.where(local_run_xrts.time <=
-    #                                          remote_run_xrts.time[-1]).dropna(
-    #                                          dim="time")
-
+    This method could be modifed in a multiple station code so that it doesn't care
+    if the station is "local" or "remote" but rather uses scale factors keyed by
+    station_id
 
     Parameters
     ----------
@@ -138,18 +134,15 @@ def make_stft_objects(processing_config, i_dec_level, run_obj, run_xrts, units,
     """
     stft_config = processing_config.get_decimation_level(i_dec_level)
     stft_obj = run_ts_to_stft(stft_config, run_xrts)
-
-    print("fix this so that it gets from config based on station_id, without caring "
-          "if local or remote")
+    # stft_obj = run_ts_to_stft_scipy(stft_config, run_xrts)
     run_id = run_obj.metadata.id
     if station_id==processing_config.stations.local.id:
         scale_factors = processing_config.stations.local.run_dict[
             run_id].channel_scale_factors
-    #Need to add logic here to look through list of remote ids
     elif station_id==processing_config.stations.remote[0].id:
         scale_factors = processing_config.stations.remote[0].run_dict[
             run_id].channel_scale_factors
-    # local_stft_obj = run_ts_to_stft_scipy(config, local_run_xrts)
+
     stft_obj = calibrate_stft_obj(
         stft_obj,
         run_obj,
@@ -321,10 +314,15 @@ def process_mth5(
         ):
     """
     1. Read in the config and figure out how many decimation levels there are
-    2. ToDo: Based on the run durations, and sampling rates, determined which runs
+    2. ToDo TFK: Based on the run durations, and sampling rates, determined which runs
     are valid for which decimation levels, or for which effective sample rates.  This
     action should be taken before we get here.  The dataset_definition should already
     be trimmed to exactly what will be processed.
+    3. ToDo TFK Check that data coverage is the same in both local and RR data
+    # if config.reference_station_id:
+    #    local_run_xrts = local_run_xrts.where(local_run_xrts.time <=
+    #                                          remote_run_xrts.time[-1]).dropna(
+    #                                          dim="time")
 
     Parameters
     ----------
@@ -351,7 +349,7 @@ def process_mth5(
     dataset_df = dataset_definition.df
 
     # Here is where any checks that would be done by TF Kernel would be applied
-
+    #see notes labelled with ToDo TFK above
 
     #Assign additional columns to dataset_df, populate with mth5_objs
     all_mth5_objs = len(dataset_df) * [None]

--- a/aurora/pipelines/process_mth5.py
+++ b/aurora/pipelines/process_mth5.py
@@ -350,6 +350,9 @@ def process_mth5(
     processing_config, mth5_objs = initialize_pipeline(config)
     dataset_df = dataset_definition.df
 
+    # Here is where any checks that would be done by TF Kernel would be applied
+
+
     #Assign additional columns to dataset_df, populate with mth5_objs
     all_mth5_objs = len(dataset_df) * [None]
     for i, station_id in enumerate(dataset_df["station_id"]):
@@ -368,6 +371,10 @@ def process_mth5(
     for i_dec_level, dec_level_config in enumerate(processing_config.decimations):
         dataset_df = populate_dataset_df(i_dec_level, dec_level_config, dataset_df)
         #ANY MERGING OF RUNS IN TIME DOMAIN WOULD GO HERE
+
+        #TFK 1: get clock-zero from data if needed
+        if dec_level_config.window.clock_zero_type == "data start":
+            dec_level_config.window.clock_zero = dataset_df.start.min().__str__()
 
         # Apply STFT to all runs
         local_stfts = []

--- a/aurora/pipelines/process_mth5.py
+++ b/aurora/pipelines/process_mth5.py
@@ -197,9 +197,17 @@ def export_tf(tf_collection, station_metadata_dict={}, survey_dict={}):
     This method may wind up being embedded in the TF class
     Assign transfer_function, residual_covariance, inverse_signal_power, station, survey
 
+    Parameters
+    ----------
+    tf_collection: aurora.transfer_function.transfer_function_collection
+    .TransferFunctionCollection
+    station_metadata_dict: dict
+    survey_dict: dict
+
     Returns
     -------
-
+    tf_cls: mt_metadata.transfer_functions.core.TF
+        Transfer function container
     """
     merged_tf_dict = tf_collection.get_merged_dict()
     tf_cls = TF()
@@ -372,7 +380,7 @@ def process_mth5(
 
         #TFK 1: get clock-zero from data if needed
         if dec_level_config.window.clock_zero_type == "data start":
-            dec_level_config.window.clock_zero = dataset_df.start.min().__str__()
+            dec_level_config.window.clock_zero = str(dataset_df.start.min())
 
         # Apply STFT to all runs
         local_stfts = []

--- a/aurora/pipelines/time_series_helpers.py
+++ b/aurora/pipelines/time_series_helpers.py
@@ -5,7 +5,6 @@ import xarray as xr
 
 from aurora.time_series.frequency_domain_helpers import get_fft_harmonics
 from aurora.time_series.windowed_time_series import WindowedTimeSeries
-from aurora.time_series.windowing_scheme import WindowingScheme
 
 def validate_sample_rate(run_ts, expected_sample_rate):
     """
@@ -94,14 +93,7 @@ def run_ts_to_stft_scipy(decimation_obj, run_xrts_orig):
         Time series of Fourier coefficients
     """
     run_xrts = apply_prewhitening(decimation_obj, run_xrts_orig)
-
-    windowing_scheme = WindowingScheme(
-        taper_family=decimation_obj.window.type,
-        num_samples_window=decimation_obj.window.num_samples,
-        num_samples_overlap=decimation_obj.window.overlap,
-        taper_additional_args=decimation_obj.window.additional_args,
-        sample_rate=decimation_obj.decimation.sample_rate,
-    )
+    windowing_scheme = decimation_obj.windowing_scheme
 
     stft_obj = xr.Dataset()
     for channel_id in run_xrts.data_vars:
@@ -160,9 +152,6 @@ def truncate_to_clock_zero(decimation_obj, run_xrts):
         pass
     else:
         clock_zero = pd.Timestamp(decimation_obj.window.clock_zero)
-        # Uncomment these two lines to test moving the clock zero around
-        # import datetime
-        # clock_zero += datetime.timedelta(seconds=-5)
         clock_zero = clock_zero.to_datetime64()
         delta_t = clock_zero - run_xrts.time[0]
         assert(delta_t.dtype == "<m8[ns]") #expected in nanoseconds
@@ -170,13 +159,15 @@ def truncate_to_clock_zero(decimation_obj, run_xrts):
         if delta_t_seconds==0:
             pass # time series start is already clock zero
         else:
+            windowing_scheme = decimation_obj.windowing_scheme
             number_of_steps = delta_t_seconds / windowing_scheme.duration_advance
             n_partial_steps = number_of_steps - np.floor(number_of_steps)
             n_clip = n_partial_steps * windowing_scheme.num_samples_advance
             n_clip = int(np.round(n_clip))
             t_clip = run_xrts.time[n_clip]
             cond1 = run_xrts.time >= t_clip
-            print(f"dropping {n_clip} samples to agree with clock zero {clock_zero}")
+            print(f"dropping {n_clip} samples to agree with "
+                  f"{decimation_obj.window.clock_zero_type} clock zero {clock_zero}")
             run_xrts = run_xrts.where(cond1, drop=True)
     return run_xrts
 
@@ -198,28 +189,13 @@ def run_ts_to_stft(decimation_obj, run_xrts_orig):
         recoloring. This really doesn't matter since we don't use the DC harmonic for
         anything.
     """
-    try:
-        windowing_scheme = WindowingScheme(
-            taper_family=decimation_obj.window.type,
-            num_samples_window=decimation_obj.window.num_samples,
-            num_samples_overlap=decimation_obj.window.overlap,
-            taper_additional_args=decimation_obj.window.additional_args,
-            sample_rate=decimation_obj.decimation.sample_rate,
-        )
-    except AttributeError:
-        print("AttributeError --- run_ts_to_stft ?")
-
-
     run_xrts = apply_prewhitening(decimation_obj, run_xrts_orig)
-
-    #optionally clip data based on clock zero
     run_xrts = truncate_to_clock_zero(decimation_obj, run_xrts)
-
+    windowing_scheme = decimation_obj.windowing_scheme
     windowed_obj = windowing_scheme.apply_sliding_window(
         run_xrts, dt=1.0 / decimation_obj.decimation.sample_rate
     )
     windowed_obj = WindowedTimeSeries.detrend(data=windowed_obj, detrend_type="linear")
-
     tapered_obj = windowed_obj * windowing_scheme.taper
     # stft_obj = WindowedTimeSeries.apply_stft(data=tapered_obj,
     #                                          sample_rate=windowing_scheme.sample_rate,

--- a/aurora/pipelines/time_series_helpers.py
+++ b/aurora/pipelines/time_series_helpers.py
@@ -28,6 +28,7 @@ def validate_sample_rate(run_ts, expected_sample_rate):
 
 def apply_prewhitening(decimation_obj, run_xrts_input):
     """
+    Applys prewhitening to time series to avoid spectral leakage when FFT is applied.
 
     Parameters
     ----------
@@ -43,7 +44,7 @@ def apply_prewhitening(decimation_obj, run_xrts_input):
 
     """
     if decimation_obj.prewhitening_type == "first difference":
-        run_xrts = run_xrts_input.diff("time")
+        run_xrts = run_xrts_input.differentiate("time")
     else:
         print(f"{decimation_obj.prewhitening_type} prehitening not yet implemented")
         print(f"returning original time series")

--- a/aurora/pipelines/time_series_helpers.py
+++ b/aurora/pipelines/time_series_helpers.py
@@ -164,6 +164,15 @@ def run_ts_to_stft(decimation_obj, run_xrts_orig):
 
     run_xrts = apply_prewhitening(decimation_obj, run_xrts_orig)
 
+    #optionally clip data based on clock zero
+    if decimation_obj.window.clock_zero_type == "ignore":
+        pass #ignore clock zero
+    elif decimation_obj.window.clock_zero_type == "data zero":
+        raise NotImplementedError
+    elif decimation_obj.window.clock_zero_type == "user defined":
+        raise NotImplementedError
+        #clock_zero = decimation_obj.window.clock_zero
+
     windowed_obj = windowing_scheme.apply_sliding_window(
         run_xrts, dt=1.0 / decimation_obj.decimation.sample_rate
     )

--- a/aurora/pipelines/time_series_helpers.py
+++ b/aurora/pipelines/time_series_helpers.py
@@ -302,7 +302,11 @@ def get_run_run_ts_from_mth5(mth5_obj, station_id, run_id, expected_sample_rate,
 
 def prototype_decimate(config, run_run_ts):
     """
-    TODO: ?Move this function into time_series/decimate.py?
+    Consider:
+    1. Moving this function into time_series/decimate.py
+    2. Replacing the downsampled_time_axis with rolling mean, or somthing that takes
+    the average value of the time, not the window start
+
     Parameters
     ----------
     config : aurora.config.metadata.decimation.Decimation
@@ -318,11 +322,8 @@ def prototype_decimate(config, run_run_ts):
     run_xrts = run_run_ts["mvts"]
     run_obj.metadata.sample_rate = config.sample_rate
 
-    # <Replace with rolling mean, somethng that works with time>
-    # and preferably takes the average time, not the start of the window
-    slicer = slice(None, None, int(config.factor))#decimation.factor
+    slicer = slice(None, None, int(config.factor)) #decimation.factor
     downsampled_time_axis = run_xrts.time.data[slicer]
-    # </Replace with rolling mean, somethng that works with time>
 
     num_observations = len(downsampled_time_axis)
     channel_labels = list(run_xrts.data_vars.keys())  # run_ts.channels

--- a/aurora/test_utils/synthetic/rms_helpers.py
+++ b/aurora/test_utils/synthetic/rms_helpers.py
@@ -39,21 +39,21 @@ def get_expected_rms_misfit(test_case_id, emtf_version=None):
     expected_rms_misfit["phi"] = {}
     if test_case_id == "test1":
         if emtf_version == "fortran":
-            expected_rms_misfit["rho"]["xy"] = 4.406358  #4.380757  # 4.357440
-            expected_rms_misfit["phi"]["xy"] = 0.862902  #0.871609  # 0.884601
-            expected_rms_misfit["rho"]["yx"] = 3.625859  #3.551043  # 3.501146
-            expected_rms_misfit["phi"]["yx"] = 0.840394  #0.812733  # 0.808658
+            expected_rms_misfit["rho"]["xy"] = 4.433905
+            expected_rms_misfit["phi"]["xy"] = 0.910484
+            expected_rms_misfit["rho"]["yx"] = 3.658614
+            expected_rms_misfit["phi"]["yx"] = 0.844645
         elif emtf_version == "matlab":
-            expected_rms_misfit["rho"]["xy"] = 2.691072
-            expected_rms_misfit["phi"]["xy"] = 0.780713
-            expected_rms_misfit["rho"]["yx"] = 3.676269
-            expected_rms_misfit["phi"]["yx"] = 1.392265
+            expected_rms_misfit["rho"]["xy"] = 2.713543
+            expected_rms_misfit["phi"]["xy"] = 0.784464
+            expected_rms_misfit["rho"]["yx"] = 3.74120
+            expected_rms_misfit["phi"]["yx"] = 1.375335
 
     elif test_case_id == "test2r1":
-        expected_rms_misfit["rho"]["xy"] = 3.940519  #3.949857  #3.949919
-        expected_rms_misfit["phi"]["xy"] = 0.959861  #0.962837  #0.957675
-        expected_rms_misfit["rho"]["yx"] = 4.136467  #4.121772  #4.117700
-        expected_rms_misfit["phi"]["yx"] = 1.635570  #1.637581  #1.629026
+        expected_rms_misfit["rho"]["xy"] = 3.971313
+        expected_rms_misfit["phi"]["xy"] = 0.982613
+        expected_rms_misfit["rho"]["yx"] = 3.967259
+        expected_rms_misfit["phi"]["yx"] = 1.62881
     return expected_rms_misfit
 
 
@@ -70,10 +70,6 @@ def assert_rms_misfit_ok(expected_rms_misfit, xy_or_yx, rho_rms_aurora,
         mode
     rho_rms_aurora: float
     phi_rms_aurora: float
-
-    Returns
-    -------
-
     """
     expected_rms_rho = expected_rms_misfit['rho'][xy_or_yx]
     expected_rms_phi = expected_rms_misfit['phi'][xy_or_yx]

--- a/tests/parkfield/test_process_parkfield_run.py
+++ b/tests/parkfield/test_process_parkfield_run.py
@@ -57,8 +57,9 @@ def test_processing(return_collection=False, z_file_path=None, test_clock_zero=F
 
     if test_clock_zero:
         for dec_lvl_cfg in p.decimations:
-            dec_lvl_cfg.window.clock_zero_type = "user specified"
-            dec_lvl_cfg.window.clock_zero = '2004-09-28 00:00:10+00:00'
+            dec_lvl_cfg.window.clock_zero_type = test_clock_zero
+            if test_clock_zero == "user specified":
+                dec_lvl_cfg.window.clock_zero = '2004-09-28 00:00:10+00:00'
 
     dataset_definition = DatasetDefinition()
     dataset_definition.df = run_summary
@@ -84,10 +85,12 @@ def test_processing(return_collection=False, z_file_path=None, test_clock_zero=F
 
 def main():
     z_file_path = AURORA_RESULTS_PATH.joinpath("pkd.zss")
-    test_processing(return_collection=True, z_file_path=z_file_path)
+    #test_processing(return_collection=True, z_file_path=z_file_path)
     test_processing(return_collection=False, z_file_path=z_file_path,
-                    test_clock_zero=True)
-    test_processing(return_collection=False, z_file_path=z_file_path)
+                    test_clock_zero="user specified")
+    test_processing(return_collection=False, z_file_path=z_file_path,
+                    test_clock_zero="data start")
+    #test_processing(return_collection=False, z_file_path=z_file_path)
 
     # COMPARE WITH ARCHIVED Z-FILE
     auxilliary_z_file = EMTF_RESULTS_PATH.joinpath("PKD_272_00.zrr")

--- a/tests/parkfield/test_process_parkfield_run.py
+++ b/tests/parkfield/test_process_parkfield_run.py
@@ -16,7 +16,7 @@ from aurora.transfer_function.plot.comparison_plots import compare_two_z_files
 from make_parkfield_mth5 import test_make_parkfield_mth5
 
 DEBUG_ISSUE_172 = False
-def test_processing(return_collection=False, z_file_path=None):
+def test_processing(return_collection=False, z_file_path=None, test_clock_zero=False):
     """
     Parameters
     ----------
@@ -48,13 +48,17 @@ def test_processing(return_collection=False, z_file_path=None):
                                         estimator={"engine":"RME"}
                                         )
     p.stations.from_dataset_dataframe(run_summary)
-    #p.validate()
 
     if DEBUG_ISSUE_172:
         config = Processing()
         config.from_json(processing_run_cfg)
     else:
         config = p
+
+    if test_clock_zero:
+        for dec_lvl_cfg in p.decimations:
+            dec_lvl_cfg.window.clock_zero_type = "user specified"
+            dec_lvl_cfg.window.clock_zero = '2004-09-28 00:00:10+00:00'
 
     dataset_definition = DatasetDefinition()
     dataset_definition.df = run_summary
@@ -81,6 +85,8 @@ def test_processing(return_collection=False, z_file_path=None):
 def main():
     z_file_path = AURORA_RESULTS_PATH.joinpath("pkd.zss")
     test_processing(return_collection=True, z_file_path=z_file_path)
+    test_processing(return_collection=False, z_file_path=z_file_path,
+                    test_clock_zero=True)
     test_processing(return_collection=False, z_file_path=z_file_path)
 
     # COMPARE WITH ARCHIVED Z-FILE

--- a/tests/parkfield/test_process_parkfield_run.py
+++ b/tests/parkfield/test_process_parkfield_run.py
@@ -85,12 +85,12 @@ def test_processing(return_collection=False, z_file_path=None, test_clock_zero=F
 
 def main():
     z_file_path = AURORA_RESULTS_PATH.joinpath("pkd.zss")
-    #test_processing(return_collection=True, z_file_path=z_file_path)
+    test_processing(return_collection=True, z_file_path=z_file_path)
     test_processing(return_collection=False, z_file_path=z_file_path,
                     test_clock_zero="user specified")
     test_processing(return_collection=False, z_file_path=z_file_path,
                     test_clock_zero="data start")
-    #test_processing(return_collection=False, z_file_path=z_file_path)
+    test_processing(return_collection=False, z_file_path=z_file_path)
 
     # COMPARE WITH ARCHIVED Z-FILE
     auxilliary_z_file = EMTF_RESULTS_PATH.joinpath("PKD_272_00.zrr")

--- a/tests/parkfield/test_process_parkfield_run.py
+++ b/tests/parkfield/test_process_parkfield_run.py
@@ -83,7 +83,7 @@ def test_processing(return_collection=False, z_file_path=None, test_clock_zero=F
 
 
 
-def main():
+def test():
     z_file_path = AURORA_RESULTS_PATH.joinpath("pkd.zss")
     test_processing(return_collection=True, z_file_path=z_file_path)
     test_processing(return_collection=False, z_file_path=z_file_path,
@@ -108,4 +108,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    test()


### PR DESCRIPTION
Added a placeholder for clock-zero.

This is two new args in the Window metadata class:

>  "clock_zero_type" & "clock_zero"

"clock_zero_type" defaults to `"ignore"`, and no change is made in the processing
"clock_zero_type" can also be `"data start"`, or `"user specified"`

if `"data start"` the earliest timestamp available is identified and added to the "clock_zero" field,
if `"user specified"` a timestamp is expected to be provided by the processing config

To think about:
Consider that prewhitening can shift the timestamp of the first sample, first difference prewhitening results in the timestamp of the first sample moving up by 1 sample_interval.  This is puzzling, because I would have thought that the timestamp should move up by one half of a sample interval.  To work around this, replaced .diff() with .differentiate() in prewhitening derivative.  

To Do:

- [x] Test that "ignore" leaves things unchanged
- [x] Make a method to identify the earliest timestamp of data in the provided data time series and add it to the config
*Note this should be done at a place in the code that has access to the dataset defintion, i.e. is "aware" of all the runs.
But we need to consider that prehitening can shift the timestamp of the first sample, ... in the case of 
- [x] Test "data start" value (this was done via manual intervention, test is not archived)
- [x] Add a synthetic (or other) test that uses the "user specified" option, and adds a timestamp to the processing config
*this was done in `test_process_parkfield_run.py`
