### PR TITLE
Multiple runs now entered into TF XML

### DIFF
--- a/aurora/tf_kernel/dataset.py
+++ b/aurora/tf_kernel/dataset.py
@@ -143,6 +143,38 @@ class KernelDataset():
     def restrict_run_intervals_to_simultaneous(self):
         raise NotImplementedError
 
+    def get_station_metadata(self, local_station_id):
+        """
+        Helper function for archiving the TF
+
+        Parameters
+        ----------
+        local_station_id: str
+            The name of the local station
+
+        Returns
+        -------
+
+        """
+        #get a list of local runs:
+        cond = self.df["station_id"] == local_station_id
+        sub_df = self.df[cond]
+
+        #sanity check:
+        run_ids = sub_df.run_id.unique()
+        assert(len(run_ids) == len(sub_df))
+
+        # iterate over these runs, packing metadata into
+        station_metadata = None
+        for i,row in sub_df.iterrows():
+            local_run_obj = row.run
+            if station_metadata is None:
+                station_metadata = local_run_obj.station_group.metadata
+                station_metadata._runs = []
+            run_metadata = local_run_obj.metadata
+            station_metadata.add_run(run_metadata)
+        return station_metadata
+
 
 
 def restrict_to_station_list(df, station_ids, inplace=True):

--- a/tests/synthetic/test_synthetic_driver.py
+++ b/tests/synthetic/test_synthetic_driver.py
@@ -137,13 +137,13 @@ def test_process_mth5():
     # process_synthetic_1_underdetermined()
     # process_synthetic_1_with_nans()
 
-    # z_file_path=AURORA_RESULTS_PATH.joinpath("syn1.zss")
-    # tfc = process_synthetic_1(z_file_path=z_file_path)
-    # z_file_path=AURORA_RESULTS_PATH.joinpath("syn1_scaled.zss")
-    # tfc = process_synthetic_1(z_file_path=z_file_path, test_scale_factor=True)
-    # z_file_path=AURORA_RESULTS_PATH.joinpath("syn1_simultaneous_estimate.zss")
-    # tfc = process_synthetic_1(z_file_path=z_file_path,
-    #                           test_simultaneous_regression=True)
+    z_file_path=AURORA_RESULTS_PATH.joinpath("syn1.zss")
+    tfc = process_synthetic_1(z_file_path=z_file_path)
+    z_file_path=AURORA_RESULTS_PATH.joinpath("syn1_scaled.zss")
+    tfc = process_synthetic_1(z_file_path=z_file_path, test_scale_factor=True)
+    z_file_path=AURORA_RESULTS_PATH.joinpath("syn1_simultaneous_estimate.zss")
+    tfc = process_synthetic_1(z_file_path=z_file_path,
+                              test_simultaneous_regression=True)
     tfc = process_synthetic_2()
     tfc = process_synthetic_rr12()
 


### PR DESCRIPTION
Add a method to KernelDataset to extract run info, looping over runs.
Also, noticed that some synthetic tests were commented out, fixed this.
Also, tidied some code in process_mth5.

[Issue(s): #181]