### PR TITLE
use mt_metadata TF instead of aurora Collection

### DIFF
--- a/aurora/pipelines/process_mth5.py
+++ b/aurora/pipelines/process_mth5.py
@@ -160,6 +160,8 @@ def export_tf(
     tf_cls: mt_metadata.transfer_functions.core.TF
         Transfer function container
     """
+    from mt_metadata.utils.list_dict import ListDict
+
     merged_tf_dict = tf_collection.get_merged_dict(channel_nomenclature)
     channel_nomenclature_dict = channel_nomenclature.to_dict()["channel_nomenclature"]
     tf_cls = TF(channel_nomenclature=channel_nomenclature_dict)
@@ -177,7 +179,7 @@ def export_tf(
     res_cov = res_cov.rename(renamer_dict)
     tf_cls.residual_covariance = res_cov
 
-    tf_cls.station_metadata._runs = []
+    tf_cls.station_metadata._runs = ListDict()
     tf_cls.station_metadata.from_dict(station_metadata_dict)
     tf_cls.survey_metadata.from_dict(survey_dict)
     return tf_cls

--- a/tests/cas04/02b_process_cas04_mth5.py
+++ b/tests/cas04/02b_process_cas04_mth5.py
@@ -167,7 +167,7 @@ def process_station_runs(local_station_id, remote_station_id="", station_runs={}
     )
     xml_file_base = f"{tmp_station_runs.label}.xml"
     xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
-    tf_result.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+    tf_result.write(fn=xml_file_name, file_type="emtfxml")
     return tf_result
 
 

--- a/tests/parkfield/test_process_parkfield_run.py
+++ b/tests/parkfield/test_process_parkfield_run.py
@@ -14,9 +14,7 @@ from aurora.transfer_function.plot.comparison_plots import compare_two_z_files
 from mth5.helpers import close_open_files
 
 
-def test_processing(
-    return_collection=False, z_file_path=None, test_clock_zero=False
-):
+def test_processing(return_collection=False, z_file_path=None, test_clock_zero=False):
     """
     Parameters
     ----------
@@ -71,7 +69,7 @@ def test_processing(
         tf_collection = tf_cls
         return tf_collection
     else:
-        tf_cls.write_tf_file(fn="emtfxml_test.xml", file_type="emtfxml")
+        tf_cls.write(fn="emtfxml_test.xml", file_type="emtfxml")
     return tf_cls
 
 

--- a/tests/parkfield/test_process_parkfield_run_rr.py
+++ b/tests/parkfield/test_process_parkfield_run_rr.py
@@ -78,7 +78,7 @@ def test_processing(z_file_path=None):
         z_file_path=z_file_path,
     )
 
-    # tf_cls.write_tf_file(fn="emtfxml_test.xml", file_type="emtfxml")
+    # tf_cls.write(fn="emtfxml_test.xml", file_type="emtfxml")
     return tf_cls
 
 

--- a/tests/synthetic/test_define_frequency_bands.py
+++ b/tests/synthetic/test_define_frequency_bands.py
@@ -38,9 +38,7 @@ def test_can_declare_frequencies_directly_in_config():
     kernel_dataset.from_run_summary(run_summary, "test1")
 
     cc = ConfigCreator()
-    cfg1 = cc.create_from_kernel_dataset(
-        kernel_dataset, estimator={"engine": "RME"}
-    )
+    cfg1 = cc.create_from_kernel_dataset(kernel_dataset, estimator={"engine": "RME"})
 
     # Default Band edges, corresponds to DEFAULT_BANDS_FILE
     band_edges = cfg1.band_edges_dict
@@ -53,9 +51,9 @@ def test_can_declare_frequencies_directly_in_config():
     )
 
     tf_cls1 = process_mth5(cfg1, kernel_dataset)
-    tf_cls1.write_tf_file(fn="cfg1.xml", file_type="emtfxml")
+    tf_cls1.write(fn="cfg1.xml", file_type="emtfxml")
     tf_cls2 = process_mth5(cfg2, kernel_dataset)
-    tf_cls2.write_tf_file(fn="cfg2.xml", file_type="emtfxml")
+    tf_cls2.write(fn="cfg2.xml", file_type="emtfxml")
     assert tf_cls2 == tf_cls1
 
 

--- a/tests/synthetic/test_multi_run.py
+++ b/tests/synthetic/test_multi_run.py
@@ -66,7 +66,7 @@ class TestMultiRunProcessing(unittest.TestCase):
             )
             xml_file_base = f"syn3_{run_id}.xml"
             xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
-            tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+            tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
     def test_all_runs(self):
         close_open_files()
@@ -88,7 +88,7 @@ class TestMultiRunProcessing(unittest.TestCase):
             z_file_path=z_file_path,
         )
         xml_file_name = AURORA_RESULTS_PATH.joinpath("syn3_all.xml")
-        tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
     def test_works_with_truncated_run(self):
         """
@@ -121,7 +121,7 @@ class TestMultiRunProcessing(unittest.TestCase):
             z_file_path=z_file_path,
         )
         xml_file_name = AURORA_RESULTS_PATH.joinpath("syn3_all_truncated_run.xml")
-        tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
 
 def main():

--- a/tests/synthetic/test_processing.py
+++ b/tests/synthetic/test_processing.py
@@ -42,18 +42,18 @@ class TestSyntheticProcessing(unittest.TestCase):
         tf_cls = process_synthetic_1(
             config_keyword="test1_tfk", z_file_path=z_file_path
         )
-        tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
         xml_file_base = "syn1r2_tfk.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
         tf_cls = process_synthetic_1r2(config_keyword="test1r2_tfk")
-        tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
     def test_can_output_tf_class_and_write_tf_xml(self):
         tf_cls = process_synthetic_1(file_version=self.file_version)
         xml_file_base = "syn1_mth5-010.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
-        tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
     def test_can_use_channel_nomenclature(self):
         channel_nomencalture = "LEMI12"
@@ -65,7 +65,7 @@ class TestSyntheticProcessing(unittest.TestCase):
         )
         xml_file_base = f"syn1_mth5-{self.file_version}_{channel_nomencalture}.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
-        tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
     def test_can_use_mth5_file_version_020(self):
         file_version = "0.2.0"
@@ -73,7 +73,7 @@ class TestSyntheticProcessing(unittest.TestCase):
         tf_cls = process_synthetic_1(z_file_path=z_file_path, file_version=file_version)
         xml_file_base = f"syn1_mth5v{file_version}.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
-        tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
     def test_can_use_scale_factor_dictionary(self):
         """
@@ -102,18 +102,18 @@ class TestSyntheticProcessing(unittest.TestCase):
         )
         xml_file_base = "syn1_simultaneous_estimate.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
-        tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
     def test_can_process_other_station(self):
         tf_cls = process_synthetic_2()
         xml_file_name = AURORA_RESULTS_PATH.joinpath("syn2.xml")
-        tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
     def test_can_process_remote_reference_data(self):
         tf_cls = process_synthetic_1r2(channel_nomenclature="default")
         xml_file_base = "syn12rr_mth5-010.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
-        tf_cls.write_tf_file(
+        tf_cls.write(
             fn=xml_file_name,
             file_type="emtfxml",
             channel_nomenclature="default",
@@ -123,7 +123,7 @@ class TestSyntheticProcessing(unittest.TestCase):
         tf_cls = process_synthetic_1r2(channel_nomenclature="LEMI34")
         xml_file_base = "syn12rr_mth5-010_LEMI34.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
-        tf_cls.write_tf_file(
+        tf_cls.write(
             fn=xml_file_name,
             file_type="emtfxml",
             channel_nomenclature="LEMI34",

--- a/tests/synthetic/test_processing.py
+++ b/tests/synthetic/test_processing.py
@@ -25,7 +25,7 @@ from mth5.helpers import close_open_files
 
 class TestSyntheticProcessing(unittest.TestCase):
     """
-    Runs several synthetic processing tests from config creation to tf_collection.
+    Runs several synthetic processing tests from config creation to tf_cls.
 
     """
 
@@ -89,12 +89,11 @@ class TestSyntheticProcessing(unittest.TestCase):
 
         """
         z_file_path = AURORA_RESULTS_PATH.joinpath("syn1-scaled.zss")
-        tf_collection = process_synthetic_1(
+        tf_cls = process_synthetic_1(
             z_file_path=z_file_path,
-            return_collection=True,
             test_scale_factor=True,
         )
-        assert tf_collection.tf_dict is not None
+        assert tf_cls.transfer_function.data.shape == (25, 3, 2)
 
     def test_simultaneous_regression(self):
         z_file_path = AURORA_RESULTS_PATH.joinpath("syn1_simultaneous_estimate.zss")
@@ -110,11 +109,7 @@ class TestSyntheticProcessing(unittest.TestCase):
         xml_file_name = AURORA_RESULTS_PATH.joinpath("syn2.xml")
         tf_cls.write_tf_file(fn=xml_file_name, file_type="emtfxml")
 
-    def test_can_process_remote_reference_data_to_tf_collection(self):
-        tf_collection = process_synthetic_1r2(return_collection=True)
-        assert tf_collection.tf_dict is not None
-
-    def test_can_process_remote_reference_data_to_tf_class(self):
+    def test_can_process_remote_reference_data(self):
         tf_cls = process_synthetic_1r2(channel_nomenclature="default")
         xml_file_base = "syn12rr_mth5-010.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
@@ -273,9 +268,10 @@ def main():
     """
     Testing the processing of synthetic data
     """
-    tmp = TestSyntheticProcessing()
-    tmp.setUp()
-    tmp.test_no_crash_with_too_many_decimations()
+    # tmp = TestSyntheticProcessing()
+    # tmp.setUp()
+    # tmp.test_no_crash_with_too_many_decimations()
+    # tmp.test_can_use_scale_factor_dictionary()
     unittest.main()
 
 

--- a/tests/synthetic/test_processing.py
+++ b/tests/synthetic/test_processing.py
@@ -116,7 +116,6 @@ class TestSyntheticProcessing(unittest.TestCase):
         tf_cls.write(
             fn=xml_file_name,
             file_type="emtfxml",
-            channel_nomenclature="default",
         )
 
     def test_can_process_remote_reference_data_with_channel_nomenclature(self):
@@ -126,7 +125,6 @@ class TestSyntheticProcessing(unittest.TestCase):
         tf_cls.write(
             fn=xml_file_name,
             file_type="emtfxml",
-            channel_nomenclature="LEMI34",
         )
 
 


### PR DESCRIPTION
This was partially addressed in December, and this commit closes the issue.  The only test using TF colleciton now is in parkfield, and this isreally only there for codecov's benefit.

[Issue(s): #143]