### PR TITLE
Fix issue 203a

### DIFF
--- a/aurora/pipelines/process_mth5.py
+++ b/aurora/pipelines/process_mth5.py
@@ -135,8 +135,7 @@ def process_tf_decimation_level(
 def export_tf(
     tf_collection,
     channel_nomenclature,
-    station_metadata_dict={},
-    survey_dict={},
+    survey_metadata={},
 ):
     """
     This method may wind up being embedded in the TF class
@@ -173,9 +172,10 @@ def export_tf(
     res_cov = res_cov.rename(renamer_dict)
     tf_cls.residual_covariance = res_cov
 
-    tf_cls.station_metadata._runs = ListDict()
-    tf_cls.station_metadata.from_dict(station_metadata_dict)
-    tf_cls.survey_metadata.from_dict(survey_dict)
+    # Set key as first el't of dict, nor currently supporting mixed surveys in TF
+    key = list(survey_metadata.keys())[0]
+    tf_cls.survey_metadata = survey_metadata[key]
+
     return tf_cls
 
 def enrich_row(row):
@@ -366,8 +366,7 @@ def process_mth5(
         tf_cls = export_tf(
             tf_collection,
             tfk.config.channel_nomenclature,
-            station_metadata_dict=station_metadata.to_dict(),
-            survey_dict=survey_dict,
+            survey_metadata=tfk_dataset.survey_metadata
         )
         tfk_dataset.close_mths_objs()
         return tf_cls

--- a/aurora/transfer_function/kernel_dataset.py
+++ b/aurora/transfer_function/kernel_dataset.py
@@ -112,6 +112,7 @@ class KernelDataset:
             "end",
             "duration",
         ]
+        self.survey_metadata = {}
 
     def clone(self):
         return copy.deepcopy(self)
@@ -349,6 +350,18 @@ class KernelDataset:
             run_ts = run_obj.to_runts(start=row.start, end=row.end)
             xr_ds = run_ts.dataset
             self.df["run_dataarray"].at[i] = xr_ds.to_array("channel")
+
+
+            # but what if RR proc with RR from other survey?
+            if i == 0:
+                if run_ts.survey_metadata.id in self.survey_metadata.keys():
+                    pass
+                self.survey_metadata[run_ts.survey_metadata.id] = run_ts.survey_metadata
+            elif i > 0:
+                self.survey_metadata[run_ts.survey_metadata.id].stations[0].add_run(run_ts.run_metadata)
+            if len(self.survey_metadata.keys()) > 1:
+                raise NotImplementedError
+
         print("DATASET DF POPULATED")
 
     def add_columns_for_processing(self, mth5_objs):

--- a/tests/synthetic/test_processing.py
+++ b/tests/synthetic/test_processing.py
@@ -41,6 +41,10 @@ class TestSyntheticProcessing(unittest.TestCase):
             config_keyword="test1_tfk", z_file_path=z_file_path
         )
         tf_cls.write(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(
+            fn=z_file_path.parent.joinpath(f"{z_file_path.stem}_from_tf.zss"),
+            file_type="zss",
+        )
 
         xml_file_base = "syn1r2_tfk.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
@@ -55,23 +59,33 @@ class TestSyntheticProcessing(unittest.TestCase):
 
     def test_can_use_channel_nomenclature(self):
         channel_nomencalture = "LEMI12"
-        z_file_path = AURORA_RESULTS_PATH.joinpath(f"syn1-{channel_nomencalture}.zss")
+        z_file_path = AURORA_RESULTS_PATH.joinpath(
+            f"syn1-{channel_nomencalture}.zss"
+        )
         tf_cls = process_synthetic_1(
             z_file_path=z_file_path,
             file_version=self.file_version,
             channel_nomenclature=channel_nomencalture,
         )
-        xml_file_base = f"syn1_mth5-{self.file_version}_{channel_nomencalture}.xml"
+        xml_file_base = (
+            f"syn1_mth5-{self.file_version}_{channel_nomencalture}.xml"
+        )
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
         tf_cls.write(fn=xml_file_name, file_type="emtfxml")
 
     def test_can_use_mth5_file_version_020(self):
         file_version = "0.2.0"
         z_file_path = AURORA_RESULTS_PATH.joinpath(f"syn1-{file_version}.zss")
-        tf_cls = process_synthetic_1(z_file_path=z_file_path, file_version=file_version)
+        tf_cls = process_synthetic_1(
+            z_file_path=z_file_path, file_version=file_version
+        )
         xml_file_base = f"syn1_mth5v{file_version}.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
         tf_cls.write(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(
+            fn=z_file_path.parent.joinpath(f"{z_file_path.stem}_from_tf.zss"),
+            file_type="zss",
+        )
 
     def test_can_use_scale_factor_dictionary(self):
         """
@@ -91,16 +105,26 @@ class TestSyntheticProcessing(unittest.TestCase):
             z_file_path=z_file_path,
             test_scale_factor=True,
         )
+        tf_cls.write(
+            fn=z_file_path.parent.joinpath(f"{z_file_path.stem}_from_tf.zss"),
+            file_type="zss",
+        )
         assert tf_cls.transfer_function.data.shape == (25, 3, 2)
 
     def test_simultaneous_regression(self):
-        z_file_path = AURORA_RESULTS_PATH.joinpath("syn1_simultaneous_estimate.zss")
+        z_file_path = AURORA_RESULTS_PATH.joinpath(
+            "syn1_simultaneous_estimate.zss"
+        )
         tf_cls = process_synthetic_1(
             z_file_path=z_file_path, simultaneous_regression=True
         )
         xml_file_base = "syn1_simultaneous_estimate.xml"
         xml_file_name = AURORA_RESULTS_PATH.joinpath(xml_file_base)
         tf_cls.write(fn=xml_file_name, file_type="emtfxml")
+        tf_cls.write(
+            fn=z_file_path.parent.joinpath(f"{z_file_path.stem}_from_tf.zss"),
+            file_type="zss",
+        )
 
     def test_can_process_other_station(self):
         tf_cls = process_synthetic_2()
@@ -212,7 +236,9 @@ def process_synthetic_1(
     if return_collection:
         z_figure_name = z_file_path.name.replace("zss", "png")
         for xy_or_yx in ["xy", "yx"]:
-            ttl_str = f"{xy_or_yx} component, test_scale_factor = {test_scale_factor}"
+            ttl_str = (
+                f"{xy_or_yx} component, test_scale_factor = {test_scale_factor}"
+            )
             out_png_name = f"{xy_or_yx}_{z_figure_name}"
             tf_result.rho_phi_plot(
                 xy_or_yx=xy_or_yx,


### PR DESCRIPTION
Updating how metadata is translated from `MTH5` to `TF`.

- updated to use only a single metadata object `survey_metadata` pulled from a `run_ts` object. 
  - Added logic to get the survey ID from `KernelDataset.df`
  - Removed older logic to get station metadata from MTH5
- Updated `tests/synthetic/test_processing.py` to output a z-file directly from `TF` object
- TODO: Pack decimation level, number of samples, and band indicies into `TF` for a more accurate and complete representation of the transfer function estimates, and output to a z-file.