### PR TITLE
Condaforge reduce memory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: /docs/figures/aurora_logo.png
+.. image:: docs/figures/aurora_logo.png
    :width: 900
    :alt: AURORA
 

--- a/aurora/pipelines/time_series_helpers.py
+++ b/aurora/pipelines/time_series_helpers.py
@@ -1,4 +1,3 @@
-from deprecated import deprecated
 import numpy as np
 import pandas as pd
 import scipy.signal as ssig

--- a/aurora/transfer_function/emtf_z_file_helpers.py
+++ b/aurora/transfer_function/emtf_z_file_helpers.py
@@ -3,7 +3,6 @@ These methods can possibly be moved under mt_metadata, or mth5
 
 They extract info needed to setup emtf_z files.
 """
-import fortranformat as ff
 import numpy as np
 
 EMTF_CHANNEL_ORDER = ["hx", "hy", "hz", "ex", "ey"]

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,6 @@ with open("README.rst") as readme_file:
 #    history = history_file.read()
 
 requirements = [
-    "dask",
-    "deprecated",
     "matplotlib",
     "mth5",
     "mt_metadata",
@@ -23,7 +21,6 @@ requirements = [
     "pandas<1.5",
     "scipy",
     "xarray",
-    "fortranformat",
 ]
 
 setup_requirements = [


### PR DESCRIPTION
Reduce imports, notably with dask, which cuts conda build memory requirements by ~2x under current build instructions