### PR TITLE
Fix issue 376

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,10 +35,9 @@ jobs:
         python --version
         conda install -c conda-forge pytest pytest-cov certifi">=2017.4.17" pandoc
         pip install -r requirements-dev.txt
-        # pip install git+https://github.com/kujaku11/mt_metadata.git@main
-        # pip install git+https://github.com/kujaku11/mth5.git@master
-        # pip install git+https://github.com/MTgeophysics/mtpy-v2.git@main
-        pip install git+https://github.com/MTgeophysics/mtpy-v2.git@main
+        pip install "mt_metadata[obspy] @ git+https://github.com/kujaku11/mt_metadata.git@main"
+        pip install git+https://github.com/kujaku11/mth5.git@processing
+        #pip install git+https://github.com/MTgeophysics/mtpy-v2.git@processing
         pip uninstall aurora -y
 
     - name: Install Our Package

--- a/aurora/sandbox/io_helpers/garys_matlab_zfiles/matlab_z_file_reader.py
+++ b/aurora/sandbox/io_helpers/garys_matlab_zfiles/matlab_z_file_reader.py
@@ -22,7 +22,7 @@ from mt_metadata.timeseries.survey import Survey
 from mt_metadata.transfer_functions.core import TF
 from loguru import logger
 
-from mtpy.processing import KernelDataset
+from mth5.processing import KernelDataset
 
 TEST_PATH = get_test_path()
 
@@ -99,9 +99,7 @@ def test_matlab_zfile_reader(case_id="IAK34ss", make_plot=False):
         ]
         reference_channels = []
         matlab_z_file = test_dir_path.joinpath("IAK34_struct_zss.mat")
-        archived_z_file_path = test_dir_path.joinpath(
-            "archived_from_matlab.zss"
-        )
+        archived_z_file_path = test_dir_path.joinpath("archived_from_matlab.zss")
         z_file_path = test_dir_path.joinpath("from_matlab.zss")
 
     # 2. Create an aurora processing config

--- a/aurora/test_utils/synthetic/make_processing_configs.py
+++ b/aurora/test_utils/synthetic/make_processing_configs.py
@@ -1,6 +1,6 @@
 """
-    This module contains methods for generating processing config objects that are
-    used in aurora's tests of processing synthetic data.
+This module contains methods for generating processing config objects that are
+used in aurora's tests of processing synthetic data.
 """
 
 from aurora.config import BANDS_DEFAULT_FILE
@@ -8,7 +8,7 @@ from aurora.config import BANDS_256_26_FILE
 from aurora.config.config_creator import ConfigCreator
 from aurora.test_utils.synthetic.paths import SyntheticTestPaths
 from loguru import logger
-from mtpy.processing import RunSummary, KernelDataset  # from mtpy-v2
+from mth5.processing import RunSummary, KernelDataset
 from typing import Optional, Union
 
 
@@ -215,7 +215,7 @@ def test_to_from_json():
     """
     # import pandas as pd
     from mt_metadata.transfer_functions.processing.aurora import Processing
-    from mtpy.processing import RunSummary, KernelDataset
+    from mth5.processing import RunSummary, KernelDataset
 
     # Specify path to mth5
     data_path = MTH5_PATH.joinpath("test1.h5")

--- a/aurora/test_utils/synthetic/processing_helpers.py
+++ b/aurora/test_utils/synthetic/processing_helpers.py
@@ -1,6 +1,6 @@
 """
-    This module contains some helper functions that are called during the
-    execution of aurora's tests of processing on synthetic data.
+This module contains some helper functions that are called during the
+execution of aurora's tests of processing on synthetic data.
 """
 
 import mt_metadata.transfer_functions
@@ -20,7 +20,7 @@ def get_example_kernel_dataset():
         The kernel dataset from a synthetic, single station mth5
     """
 
-    from mtpy.processing import RunSummary, KernelDataset
+    from mth5.processing import RunSummary, KernelDataset
 
     mth5_path = create_test1_h5(force_make_mth5=False)
 
@@ -46,7 +46,7 @@ def tf_obj_from_synthetic_data(
 
     """
     from aurora.config.config_creator import ConfigCreator
-    from mtpy.processing import RunSummary, KernelDataset
+    from mth5.processing import RunSummary, KernelDataset
 
     run_summary = RunSummary()
     run_summary.from_mth5s(list((mth5_path,)))

--- a/docs/examples/operate_aurora.ipynb
+++ b/docs/examples/operate_aurora.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -63,7 +63,7 @@
     "from aurora.config import BANDS_DEFAULT_FILE\n",
     "from aurora.config.config_creator import ConfigCreator\n",
     "from aurora.pipelines.process_mth5 import process_mth5\n",
-    "from mtpy.processing import RunSummary, KernelDataset\n",
+    "from mth5.processing import RunSummary, KernelDataset\n",
     "\n",
     "warnings.filterwarnings('ignore')"
    ]

--- a/docs/tutorials/process_cas04_multiple_station.ipynb
+++ b/docs/tutorials/process_cas04_multiple_station.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "95ae061a-dc05-471b-a88c-4aaaef4ddc50",
    "metadata": {},
    "outputs": [
@@ -55,7 +55,7 @@
     "from mth5.mth5 import MTH5\n",
     "from mth5.clients.make_mth5 import FDSN\n",
     "from mth5.utils.helpers import initialize_mth5\n",
-    "from mtpy.processing import RunSummary, KernelDataset\n"
+    "from mth5.processing import RunSummary, KernelDataset\n"
    ]
   },
   {
@@ -5717,14 +5717,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "id": "52f879f8-3743-4966-8452-3369c942d703",
    "metadata": {},
    "outputs": [],
    "source": [
     "from aurora.config.config_creator import ConfigCreator\n",
     "from aurora.pipelines.process_mth5 import process_mth5\n",
-    "from mtpy.processing import KernelDataset, RunSummary"
+    "from mth5.processing import KernelDataset, RunSummary"
    ]
   },
   {

--- a/docs/tutorials/processing_configuration.ipynb
+++ b/docs/tutorials/processing_configuration.ipynb
@@ -147,13 +147,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "8e3a5ef1-b00d-4263-890a-cfe028a712b9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from aurora.test_utils.synthetic.paths import SyntheticTestPaths\n",
-    "from mtpy.processing import RunSummary, KernelDataset\n",
+    "from mth5.data.paths import SyntheticTestPaths\n",
+    "from mth5.processing import RunSummary, KernelDataset\n",
     "\n",
     "synthetic_test_paths = SyntheticTestPaths()\n",
     "MTH5_PATH = synthetic_test_paths.mth5_path"

--- a/docs/tutorials/synthetic_data_processing.ipynb
+++ b/docs/tutorials/synthetic_data_processing.ipynb
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -68,7 +68,7 @@
     "from aurora.pipelines.process_mth5 import process_mth5\n",
     "from mth5.data.make_mth5_from_asc import create_test12rr_h5\n",
     "from mth5.data.paths import SyntheticTestPaths\n",
-    "from mtpy.processing import RunSummary, KernelDataset\n",
+    "from mth5.processing import RunSummary, KernelDataset\n",
     "\n",
     "warnings.filterwarnings('ignore')"
    ]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.rst") as readme_file:
 requirements = [
     # "mt_metadata",
     # "mth5",
-    "mtpy-v2",
+    # "mtpy-v2",
     "numba",
     "psutil",
 ]

--- a/tests/cas04/02b_process_cas04_mth5.py
+++ b/tests/cas04/02b_process_cas04_mth5.py
@@ -59,7 +59,7 @@ from aurora.general_helper_functions import get_test_path
 from aurora.pipelines.process_mth5 import process_mth5
 from aurora.transfer_function.plot.comparison_plots import compare_two_z_files
 
-from mtpy.processing import RunSummary, KernelDataset
+from mth5.processing import RunSummary, KernelDataset
 
 from loguru import logger
 
@@ -125,9 +125,7 @@ class StationRuns(UserDict):
         return out_file
 
 
-def process_station_runs(
-    local_station_id, remote_station_id="", station_runs={}
-):
+def process_station_runs(local_station_id, remote_station_id="", station_runs={}):
     """
 
     Parameters
@@ -154,9 +152,7 @@ def process_station_runs(
 
     # Pass the run_summary to a Dataset class
     kernel_dataset = KernelDataset()
-    kernel_dataset.from_run_summary(
-        run_summary, local_station_id, remote_station_id
-    )
+    kernel_dataset.from_run_summary(run_summary, local_station_id, remote_station_id)
 
     # reduce station_runs_dict to only relevant stations
 

--- a/tests/parkfield/test_process_parkfield_run.py
+++ b/tests/parkfield/test_process_parkfield_run.py
@@ -1,12 +1,12 @@
+from loguru import logger
+
 from aurora.config.config_creator import ConfigCreator
 from aurora.pipelines.process_mth5 import process_mth5
 from aurora.test_utils.parkfield.make_parkfield_mth5 import ensure_h5_exists
 from aurora.test_utils.parkfield.path_helpers import PARKFIELD_PATHS
 from aurora.transfer_function.plot.comparison_plots import compare_two_z_files
 
-from mtpy.processing import RunSummary, KernelDataset
-
-from loguru import logger
+from mth5.processing import RunSummary, KernelDataset
 from mth5.helpers import close_open_files
 
 

--- a/tests/parkfield/test_process_parkfield_run_rr.py
+++ b/tests/parkfield/test_process_parkfield_run_rr.py
@@ -1,3 +1,5 @@
+from loguru import logger
+
 from aurora.config.config_creator import ConfigCreator
 from aurora.pipelines.process_mth5 import process_mth5
 from aurora.sandbox.mth5_channel_summary_helpers import (
@@ -7,11 +9,9 @@ from aurora.test_utils.parkfield.make_parkfield_mth5 import ensure_h5_exists
 from aurora.test_utils.parkfield.path_helpers import PARKFIELD_PATHS
 from aurora.transfer_function.plot.comparison_plots import compare_two_z_files
 
-from mtpy.processing import RunSummary, KernelDataset
-
-from loguru import logger
 from mth5.mth5 import MTH5
 from mth5.helpers import close_open_files
+from mth5.processing import RunSummary, KernelDataset
 
 
 def test_stuff_that_belongs_elsewhere():

--- a/tests/parkfield/test_process_parkfield_run_rr.py
+++ b/tests/parkfield/test_process_parkfield_run_rr.py
@@ -7,11 +7,10 @@ from aurora.test_utils.parkfield.make_parkfield_mth5 import ensure_h5_exists
 from aurora.test_utils.parkfield.path_helpers import PARKFIELD_PATHS
 from aurora.transfer_function.plot.comparison_plots import compare_two_z_files
 
-from mtpy.processing import RunSummary, KernelDataset
-
 from loguru import logger
 from mth5.mth5 import MTH5
 from mth5.helpers import close_open_files
+from mth5.processing import RunSummary, KernelDataset
 
 
 def test_stuff_that_belongs_elsewhere():

--- a/tests/parkfield/test_process_parkfield_run_rr.py
+++ b/tests/parkfield/test_process_parkfield_run_rr.py
@@ -7,10 +7,11 @@ from aurora.test_utils.parkfield.make_parkfield_mth5 import ensure_h5_exists
 from aurora.test_utils.parkfield.path_helpers import PARKFIELD_PATHS
 from aurora.transfer_function.plot.comparison_plots import compare_two_z_files
 
+from mtpy.processing import RunSummary, KernelDataset
+
 from loguru import logger
 from mth5.mth5 import MTH5
 from mth5.helpers import close_open_files
-from mth5.processing import RunSummary, KernelDataset
 
 
 def test_stuff_that_belongs_elsewhere():

--- a/tests/synthetic/test_compare_aurora_vs_archived_emtf.py
+++ b/tests/synthetic/test_compare_aurora_vs_archived_emtf.py
@@ -14,12 +14,10 @@ from aurora.transfer_function.emtf_z_file_helpers import (
     merge_tf_collection_to_match_z_file,
 )
 
-# from mtpy-v2
-from mtpy.processing import RunSummary, KernelDataset
-
 from plot_helpers_synthetic import plot_rho_phi
 from loguru import logger
 from mth5.helpers import close_open_files
+from mth5.processing import RunSummary, KernelDataset
 
 synthetic_test_paths = SyntheticTestPaths()
 synthetic_test_paths.mkdirs()
@@ -87,9 +85,7 @@ def aurora_vs_emtf(
     )
 
     aux_data = read_z_file(auxilliary_z_file)
-    aurora_rho_phi = merge_tf_collection_to_match_z_file(
-        aux_data, tf_collection
-    )
+    aurora_rho_phi = merge_tf_collection_to_match_z_file(aux_data, tf_collection)
     data_dict = {}
     data_dict["period"] = aux_data.periods
     data_dict["emtf_rho_xy"] = aux_data.rxy
@@ -146,9 +142,7 @@ def run_test1(emtf_version, ds_df):
     test_case_id = "test1"
     auxilliary_z_file = EMTF_RESULTS_PATH.joinpath("test1.zss")
     z_file_base = f"{test_case_id}_aurora_{emtf_version}.zss"
-    aurora_vs_emtf(
-        test_case_id, emtf_version, auxilliary_z_file, z_file_base, ds_df
-    )
+    aurora_vs_emtf(test_case_id, emtf_version, auxilliary_z_file, z_file_base, ds_df)
     return
 
 

--- a/tests/synthetic/test_fourier_coefficients.py
+++ b/tests/synthetic/test_fourier_coefficients.py
@@ -1,4 +1,5 @@
 import unittest
+from loguru import logger
 
 from aurora.config.config_creator import ConfigCreator
 from aurora.pipelines.fourier_coefficients import add_fcs_to_mth5
@@ -9,16 +10,14 @@ from aurora.test_utils.synthetic.make_processing_configs import (
     create_test_run_config,
 )
 from aurora.test_utils.synthetic.paths import SyntheticTestPaths
+
 from mth5.data.make_mth5_from_asc import create_test1_h5
 from mth5.data.make_mth5_from_asc import create_test2_h5
 from mth5.data.make_mth5_from_asc import create_test3_h5
 from mth5.data.make_mth5_from_asc import create_test12rr_h5
-
-# from mtpy-v2
-from mtpy.processing import RunSummary, KernelDataset
-
-from loguru import logger
+from mth5.processing import RunSummary, KernelDataset
 from mth5.helpers import close_open_files
+
 
 synthetic_test_paths = SyntheticTestPaths()
 synthetic_test_paths.mkdirs()

--- a/tests/synthetic/test_metadata_values_set_correctly.py
+++ b/tests/synthetic/test_metadata_values_set_correctly.py
@@ -7,8 +7,7 @@ import logging
 import pandas as pd
 import unittest
 
-# from mtpy-v2
-from mtpy.processing import RunSummary
+from mth5.processing import RunSummary
 from mth5.data.make_mth5_from_asc import create_test3_h5
 from mth5.data.station_config import make_station_03
 from mth5.helpers import close_open_files

--- a/tests/synthetic/test_multi_run.py
+++ b/tests/synthetic/test_multi_run.py
@@ -1,13 +1,13 @@
 import logging
 import unittest
+
 from aurora.config.config_creator import ConfigCreator
 from aurora.pipelines.process_mth5 import process_mth5
 from aurora.test_utils.synthetic.paths import SyntheticTestPaths
+
 from mth5.data.make_mth5_from_asc import create_test3_h5
 from mth5.helpers import close_open_files
-
-# from mtpy-v2
-from mtpy.processing import RunSummary, KernelDataset
+from mth5.processing import RunSummary, KernelDataset
 
 synthetic_test_paths = SyntheticTestPaths()
 synthetic_test_paths.mkdirs()

--- a/tests/synthetic/test_stft_methods_agree.py
+++ b/tests/synthetic/test_stft_methods_agree.py
@@ -3,6 +3,7 @@ See aurora issue #3.  This test confirms that the internal aurora stft
 method returns the same array as scipy.signal.spectrogram
 """
 
+from loguru import logger
 import numpy as np
 
 from aurora.pipelines.time_series_helpers import prototype_decimate
@@ -12,10 +13,7 @@ from aurora.test_utils.synthetic.make_processing_configs import (
     create_test_run_config,
 )
 
-# from mtpy-v2
-from mtpy.processing import RunSummary, KernelDataset
-
-from loguru import logger
+from mth5.processing import RunSummary, KernelDataset
 from mth5.data.make_mth5_from_asc import create_test1_h5
 from mth5.mth5 import MTH5
 from mth5.helpers import close_open_files
@@ -68,9 +66,7 @@ def test_stft_methods_agree():
             run_ts = run_obj.to_runts(start=None, end=None)
             local_run_xrts = run_ts.dataset
         else:
-            local_run_xrts = prototype_decimate(
-                dec_config.decimation, local_run_xrts
-            )
+            local_run_xrts = prototype_decimate(dec_config.decimation, local_run_xrts)
 
         dec_config.extra_pre_fft_detrend_type = "constant"
         local_stft_obj = run_ts_to_stft(dec_config, local_run_xrts)


### PR DESCRIPTION
This PR will close issue #376 on circular dependencies.  The fix is moving `RunSummary` and `KernelDataset` to `mth5` from `mtpy-v2`.  This will allow users to access those objects without using `mtpy-v2`, it also removes any dependency of `aurora` on `mtpy-v2`.

- [x] Update imports from `mtpy` to `mth5`