### PR TITLE
Update imports for splitting mth5 to other modules

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,78 @@
+name: Bump version and changelog
+
+on:
+  pull_request:
+    types: [labeled]
+    branches:
+      - main
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  bump-version-and-changelog:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'release:major') ||
+      contains(github.event.pull_request.labels.*.name, 'release:minor') ||
+      contains(github.event.pull_request.labels.*.name, 'release:patch')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install tools
+        run: |
+          pip install bump-my-version build pandoc
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+          cargo install git-cliff
+
+      - name: Set up Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Determine version bump type
+        id: bump
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'release:major') }}" == "true" ]]; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'release:minor') }}" == "true" ]]; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          else
+            echo "type=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bump version
+        run: bump-my-version bump ${{ steps.bump.outputs.type }}
+        env:
+          BMV_ALLOW_DIRTY: "true"
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(bump-my-version show current)
+          echo "Extracted version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog
+        run: |
+          git cliff -o CHANGELOG.md
+          echo "Generated changelog for version ${{ steps.version.outputs.version }}"
+
+      - name: Commit and push changes to PR branch
+        run: |
+          git add .
+          git commit -m "chore: bump version to ${{ steps.version.outputs.version }} and update changelog [skip ci]" || echo "No changes to commit"
+          git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,98 +1,19 @@
-name: Publish on PR merge
+name: Publish release
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, closed]
+    types: [closed]
     branches:
       - main
 
 permissions:
   contents: write
   id-token: write
-  pull-requests: write
 
 jobs:
-  update-version-and-changelog:
-    # Run only when a release label is added (not on every push)
-    if: |
-      github.event.action == 'labeled' &&
-      github.event.pull_request.merged == false && (
-        contains(github.event.pull_request.labels.*.name, 'release:major') ||
-        contains(github.event.pull_request.labels.*.name, 'release:minor') ||
-        contains(github.event.pull_request.labels.*.name, 'release:patch')
-      )
+  publish:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out PR branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install tools
-        run: |
-          pip install bump-my-version build pandoc
-          sudo apt-get update
-          sudo apt-get install -y pandoc
-          cargo install git-cliff
-
-      - name: Set up Git user
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
-      - name: Determine version bump type
-        id: bump
-        run: |
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'release:major') }}" == "true" ]]; then
-            echo "type=major" >> $GITHUB_OUTPUT
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'release:minor') }}" == "true" ]]; then
-            echo "type=minor" >> $GITHUB_OUTPUT
-          else
-            echo "type=patch" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Bump version
-        run: bump-my-version bump ${{ steps.bump.outputs.type }}
-        env:
-          BMV_ALLOW_DIRTY: "true"
-
-      - name: Extract version
-        id: version
-        run: |
-          VERSION=$(bump-my-version show current)
-          echo "Extracted version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Generate changelog
-        run: |
-          git cliff -o CHANGELOG.md
-          echo "Generated changelog for version ${{ steps.version.outputs.version }}"
-
-
-      - name: Commit and push changes to PR branch
-        run: |
-          git add .
-          git commit -m "chore: bump version to ${{ steps.version.outputs.version }} and update changelog [skip ci]" || echo "No changes to commit"
-          git push origin HEAD:${{ github.head_ref }}
-
-  publish-after-merge:
-    # Run only after PR is merged with release labels
-    if: |
-      github.event.pull_request.merged == true && (
-        contains(github.event.pull_request.labels.*.name, 'release:major') ||
-        contains(github.event.pull_request.labels.*.name, 'release:minor') ||
-        contains(github.event.pull_request.labels.*.name, 'release:patch')
-      )
-    runs-on: ubuntu-latest
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/test_notebooks.yaml
+++ b/.github/workflows/test_notebooks.yaml
@@ -61,7 +61,7 @@ jobs:
           # uv pip install "mt_metadata[obspy] @ git+https://github.com/kujaku11/mt_metadata@patches"
           # uv pip install "mt_metadata[obspy]"
           # uv pip install mth5
-          uv pip install git+https://github.com/kujaku11/mth5@split_io
+          uv pip install git+https://github.com/kujaku11/mth5@patches
           uv pip install git+https://github.com/kujaku11/mth5_test_data.git
           # Explicitly include nbconvert & ipykernel
           uv pip install jupyter nbconvert nbformat ipykernel

--- a/.github/workflows/test_notebooks.yaml
+++ b/.github/workflows/test_notebooks.yaml
@@ -57,8 +57,9 @@ jobs:
           uv pip install --upgrade pip
           uv pip install 'setuptools<68'
           uv pip install -e ".[dev,test]"
-          uv pip install mt_metadata[obspy]
-          uv pip install "mt_metadata[obspy]"
+          # uv pip install mt_metadata[obspy]
+          uv pip install "mt_metadata[obspy] @ git+https://github.com/kujaku11/mt_metadata@patches"
+          # uv pip install "mt_metadata[obspy]"
           # uv pip install mth5
           uv pip install git+https://github.com/kujaku11/mth5@split_io
           uv pip install git+https://github.com/kujaku11/mth5_test_data.git

--- a/.github/workflows/test_notebooks.yaml
+++ b/.github/workflows/test_notebooks.yaml
@@ -59,7 +59,8 @@ jobs:
           uv pip install -e ".[dev,test]"
           uv pip install mt_metadata[obspy]
           uv pip install "mt_metadata[obspy]"
-          uv pip install mth5
+          # uv pip install mth5
+          uv pip install git+https://github.com/kujaku11/mth5@split_io
           uv pip install git+https://github.com/kujaku11/mth5_test_data.git
           # Explicitly include nbconvert & ipykernel
           uv pip install jupyter nbconvert nbformat ipykernel

--- a/.github/workflows/test_notebooks.yaml
+++ b/.github/workflows/test_notebooks.yaml
@@ -57,8 +57,8 @@ jobs:
           uv pip install --upgrade pip
           uv pip install 'setuptools<68'
           uv pip install -e ".[dev,test]"
-          # uv pip install mt_metadata[obspy]
-          uv pip install "mt_metadata[obspy] @ git+https://github.com/kujaku11/mt_metadata@patches"
+          uv pip install mt_metadata[obspy]
+          # uv pip install "mt_metadata[obspy] @ git+https://github.com/kujaku11/mt_metadata@patches"
           # uv pip install "mt_metadata[obspy]"
           # uv pip install mth5
           uv pip install git+https://github.com/kujaku11/mth5@split_io

--- a/.github/workflows/test_notebooks.yaml
+++ b/.github/workflows/test_notebooks.yaml
@@ -57,11 +57,6 @@ jobs:
           uv pip install --upgrade pip
           uv pip install 'setuptools<68'
           uv pip install -e ".[dev,test]"
-          uv pip install mt_metadata[obspy]
-          # uv pip install "mt_metadata[obspy] @ git+https://github.com/kujaku11/mt_metadata@patches"
-          # uv pip install "mt_metadata[obspy]"
-          # uv pip install mth5
-          uv pip install git+https://github.com/kujaku11/mth5@patches
           uv pip install git+https://github.com/kujaku11/mth5_test_data.git
           # Explicitly include nbconvert & ipykernel
           uv pip install jupyter nbconvert nbformat ipykernel

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,14 +48,6 @@ jobs:
           uv pip install --upgrade pip
           uv pip install 'setuptools<68'
           uv pip install -e ".[dev,test]"
-          uv pip install mt_metadata[obspy]
-          # uv pip install "mt_metadata[obspy] @ git+https://github.com/kujaku11/mt_metadata.git@patches"
-          # uv pip install git+https://github.com/kujaku11/mth5.git@patches
-          # uv pip install "mt_metadata[obspy] @ git+https://github.com/kujaku11/mt_metadata.git"
-          # uv pip install git+https://github.com/kujaku11/mth5.git
-          uv pip install "mt_metadata[obspy]"
-          uv pip install git+https://github.com/kujaku11/mth5.git@patches
-          # uv pip install mth5
           uv pip install git+https://github.com/kujaku11/mth5_test_data.git
           # Explicitly include nbconvert & ipykernel
           uv pip install jupyter nbconvert nbformat ipykernel pytest pytest-cov pytest-timeout codecov

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,7 +54,7 @@ jobs:
           # uv pip install "mt_metadata[obspy] @ git+https://github.com/kujaku11/mt_metadata.git"
           # uv pip install git+https://github.com/kujaku11/mth5.git
           uv pip install "mt_metadata[obspy]"
-          uv pip install git+https://github.com/kujaku11/mth5.git@split_io
+          uv pip install git+https://github.com/kujaku11/mth5.git@patches
           # uv pip install mth5
           uv pip install git+https://github.com/kujaku11/mth5_test_data.git
           # Explicitly include nbconvert & ipykernel

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,9 +54,7 @@ jobs:
           # uv pip install "mt_metadata[obspy] @ git+https://github.com/kujaku11/mt_metadata.git"
           # uv pip install git+https://github.com/kujaku11/mth5.git
           uv pip install "mt_metadata[obspy]"
-          uv pip install mth5
-          
-          
+          uv pip install git+https://github.com/kujaku11/mth5.git@split_io
           # uv pip install mth5
           uv pip install git+https://github.com/kujaku11/mth5_test_data.git
           # Explicitly include nbconvert & ipykernel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Miscellaneous Tasks
+
+- Bump version to  and update changelog [skip ci] ([c1576f6](c1576f6e249323b81f3a00dc19f48b25de820a07))
+
+
 ## Bug Fixes
 
 - Fix filter additons to use new add_filter method ([56ab23a](56ab23a18023e01be92e5af5126351236c7dcdd2))

--- a/aurora/__init__.py
+++ b/aurora/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 import sys
 from loguru import logger

--- a/aurora/time_series/frequency_band_helpers.py
+++ b/aurora/time_series/frequency_band_helpers.py
@@ -2,14 +2,13 @@
     This module contains functions that are associated with time series of Fourier coefficients
     TODO: Move these methods to mth5.processing.spectre.frequency_band_helpers
 """
-from loguru import logger
-from mt_metadata.processing.aurora import (
-    DecimationLevel as AuroraDecimationLevel,
-)
-from mt_metadata.processing.aurora import Band
-from mth5.timeseries.spectre.spectrogram import extract_band
 from typing import Optional, Tuple
+
 import xarray as xr
+from loguru import logger
+from mt_metadata.processing.aurora import Band
+from mt_metadata.processing.aurora import DecimationLevel as AuroraDecimationLevel
+from mt_timeseries.spectre.spectrogram import extract_band
 
 
 def get_band_for_tf_estimate(

--- a/docs/examples/operate_aurora.ipynb
+++ b/docs/examples/operate_aurora.ipynb
@@ -2968,7 +2968,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2983,12 +2983,12 @@
     }
    ],
    "source": [
-    "tf_cls.write(fn=\"emtfxml_test.xml\", file_type=\"emtfxml\")"
+    "tf_cls.write(\"emtfxml_test.xml\", file_type=\"emtfxml\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3016,12 +3016,12 @@
     }
    ],
    "source": [
-    "tf_cls.write(fn=\"emtfxml_test.edi\", file_type=\"edi\")"
+    "tf_cls.write(\"emtfxml_test.edi\", file_type=\"edi\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3036,7 +3036,7 @@
     }
    ],
    "source": [
-    "tf_cls.write(fn=\"emtfxml_test.zss\", file_type=\"zmm\")"
+    "tf_cls.write(\"emtfxml_test.zss\", file_type=\"zmm\")"
    ]
   },
   {

--- a/docs/tutorials/process_cas04_multiple_station.ipynb
+++ b/docs/tutorials/process_cas04_multiple_station.ipynb
@@ -3033,7 +3033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "2ee6e117-c7e1-40ba-9981-5f2a189e404a",
    "metadata": {},
    "outputs": [
@@ -3049,9 +3049,9 @@
     }
    ],
    "source": [
-    "tf_cls.write(fn=f\"{tf_file_base}.xml\", file_type=\"emtfxml\")\n",
-    "tf_cls.write(fn=f\"{tf_file_base}.edi\", file_type=\"edi\")\n",
-    "tf_cls.write(fn=f\"{tf_file_base}.zrr\", file_type=\"zrr\")"
+    "tf_cls.write(f\"{tf_file_base}.xml\", file_type=\"emtfxml\")\n",
+    "tf_cls.write(f\"{tf_file_base}.edi\", file_type=\"edi\")\n",
+    "tf_cls.write(f\"{tf_file_base}.zrr\", file_type=\"zrr\")"
    ]
   },
   {
@@ -7048,7 +7048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "id": "358195b0",
    "metadata": {},
    "outputs": [
@@ -7077,7 +7077,7 @@
     }
    ],
    "source": [
-    "tf.write(fn=\"CAS04_rrNVR08.edi\", file_type=\"edi\")"
+    "tf.write(\"CAS04_rrNVR08.edi\", file_type=\"edi\")"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "mth5>=0.6.0",
+    "mth5>=0.6.7",
     "numba>=0.58",
     "obspy",
     "psutil",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aurora"
-version = "0.6.1"
+version = "0.6.2"
 description = "Processing Codes for Magnetotelluric Data"
 readme = "README.rst"
 requires-python = ">=3.10"
@@ -76,7 +76,7 @@ dev = [
 ]
 
 [tool.bumpversion]
-current_version = "0.6.1"
+current_version = "0.6.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true


### PR DESCRIPTION
The newer version of `mth5` has split modules into separate repositories so fixing the imports.

Just one import path needed to be changed.